### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ language: ruby
 rvm:
   - 2.2.4
 before_install: 
-  - rvm gemset create openstudio
-  - rvm 2.2.4@openstudio
   - gem install bundler -v 1.14.4
   - gem install rake -v 12.3.1
 install: 
   - bundle _1.14.4_ install
 script:
-  - bundle _1.14.4_ exec rake _12.3.1_ make_package
+  - bundle exec rake make_package


### PR DESCRIPTION
I think this will do what you need. Once you install the gems, then you don't need to specify the version of bundler nor rake.

There are several warnings in travis, but I think those are past the bundle issue.

```
The git source `git://github.com/NREL/simplecov.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
Unable to remove the platform `mri` since the only platforms are ruby
./build/ruby/2.2.0/bin/bundle _1.14.4_ lock --remove_platform mingw
The git source `git://github.com/NREL/simplecov.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
Unable to remove the platform `mingw` since the only platforms are ruby
./build/ruby/2.2.0/bin/bundle _1.14.4_ lock --remove_platform x64_mingw
The git source `git://github.com/NREL/simplecov.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
Unable to remove the platform `x64_mingw` since the only platforms are ruby
./build/ruby/2.2.0/bin/bundle _1.14.4_ lock --remove_platform x64-mingw32
The git source `git://github.com/NREL/simplecov.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
Unable to remove the platform `x64-mingw32` since the only platforms are ruby
./build/ruby/2.2.0/bin/bundle _1.14.4_ lock --remove_platform rbx
The git source `git://github.com/NREL/simplecov.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
Unable to remove the platform `rbx` since the only platforms are ruby
./build/ruby/2.2.0/bin/bundle _1.14.4_ lock --remove_platform jruby
The git source `git://github.com/NREL/simplecov.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
Unable to remove the platform `jruby` since the only platforms are ruby
./build/ruby/2.2.0/bin/bundle _1.14.4_ lock --remove_platform mswin
The git source `git://github.com/NREL/simplecov.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
Unable to remove the platform `mswin` since the only platforms are ruby
./build/ruby/2.2.0/bin/bundle _1.14.4_ lock --remove_platform mswin64
The git source `git://github.com/NREL/simplecov.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
Unable to remove the platform `mswin64` since the only platforms are ruby
```