### PR TITLE
adding Jenkisfile for Jenkins CI pipeline job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,5 @@
+//Jenkins pipelines are stored in shared libaries. https://github.com/NREL/cbci_jenkins_libs
+ 
+@Library('cbci_shared_libs@develop') _
+
+openstudio_extension_gems() 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@
  
 @Library('cbci_shared_libs@develop') _
 
-openstudio_extension_gems() 
+openstudio_gems() 

--- a/Jenkisfile
+++ b/Jenkisfile
@@ -1,0 +1,5 @@
+//Jenkins pipelines are stored in shared libaries. https://github.com/NREL/cbci_jenkins_libs
+ 
+@Library('cbci_shared_libs@develop') _
+
+openstudio_extension_gems() 


### PR DESCRIPTION
For issue (https://github.com/NREL/openstudio-gems/issues/2)
Adding CI Jenkins job to run this. 

Logic is as follows: 
- All PRs to develop will run but the build artifact with not be pushed to s3. 
- All commits to develop and master branch will be built and then uploaded to s3://openstudio-resources/dependencies/

We can turn off Travis once this is up and running. 


