### PR TITLE
Bundler bump to 2.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ language: ruby
 rvm:
   - 2.5.5
 before_install:
-  - gem install bundler -v '1.17.1'
-  - gem install bundler -v '~> 1.17.1'
+  - gem install bundler -v '2.1.1'
+  - gem install bundler -v '~> 2.1.1'
 install:
   - bundle install
 script:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 //Jenkins pipelines are stored in shared libaries. https://github.com/NREL/cbci_jenkins_libs
-
-@Library('cbci_shared_libs') _
+// TODO: temporary
+@Library('cbci_shared_libs@update_gems_255') _
 
 openstudio3_gems()

--- a/openstudio-gems.gemspec
+++ b/openstudio-gems.gemspec
@@ -24,10 +24,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'parallel', '1.12.1'
   spec.add_dependency 'json_pure', '2.2'
   spec.add_dependency 'pycall', '1.2.1'
-  
+
   # development dependencies need not be specified so strictly
   # these will not be enforced by consumers of this spec
   # bundle version is parsed by build_openstudio_gems.rb, specify all three numbers
   spec.add_development_dependency 'rake', '~> 12.3'
-  spec.add_development_dependency 'bundler', '~> 1.17.1'
+  spec.add_development_dependency 'bundler', '~> 2.0.0'
 end

--- a/openstudio-gems.gemspec
+++ b/openstudio-gems.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   # these will not be enforced by consumers of this spec
   # bundle version is parsed by build_openstudio_gems.rb, specify all three numbers
   spec.add_development_dependency 'rake', '~> 12.3'
-  spec.add_development_dependency 'bundler', '~> 2.0.0'
+  spec.add_development_dependency 'bundler', '~> 2.1.0'
 end


### PR DESCRIPTION
Fix #8 ?

Perhaps should be changed to `~> 2.0` instead (meaning any 2.x is fine)
Potentially could fix the issue https://github.com/NREL/OpenStudio/issues/3733

@tijcolem, Fix also needs to happen on Jenkins, https://github.com/NREL/cbci_jenkins_libs/pull/62