### PR TITLE
adding google-protobuf gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,5 +27,6 @@ gem 'simplecov', :github => 'NREL/simplecov', :ref => '98c33ffcb40fe867857a44b4d
 gem 'openstudio_measure_tester', '= 0.1.7' # This includes the dependencies for running unit tests, coverage, and rubocop
 #gem 'openstudio_measure_tester', :github => 'NREL/OpenStudio-measure-tester-gem', :ref => '273d1f1a5c739312688ea605ef4a5b6e7325332c'
 
+# List of supported native gems
 gem 'pycall', '= 1.2.1', :github => 'NREL/pycall.rb', :ref => '5d60b274ac646cdb422a436aad98b40ef8b902b8'
-
+gem 'google-protobuf', :github => 'protocolbuffers/protobuf', :branch => '3.11.x'


### PR DESCRIPTION
Adding another native ext gem (google-protobuf) to embed in OpenStudio CLI. 
