### PR TITLE
update version of openstudio measure tester

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,14 +11,13 @@ gemspec
 # Specify specific gem source/location (e.g. github branch) for running bundle in this directory
 # This is needed if the version of the gem you want to use is not on rubygems
 
-#gem 'openstudio-extension', '= 0.2.1'
+gem 'openstudio-extension', '= 0.2.1'
 # TODO: Temp
-gem 'openstudio-extension', :github => 'NREL/OpenStudio-extension-gem', :ref => 'Bump_deps'
 
 gem 'openstudio-workflow', '= 2.0.0'
 #gem 'openstudio-workflow', :github => 'NREL/OpenStudio-workflow-gem', :ref => '3e62211b29e28d341c4a84794f35a772c91a2145'
 
-gem 'openstudio-standards', '= 0.2.11.rc2'
+gem 'openstudio-standards', '= 0.2.11'
 #gem 'openstudio-standards', :github => 'NREL/openstudio-standards', :ref => '77cc9971e00b603224a074bb21ce44aa61de7c3d'
 
 # openstudio_measure_tester is redundant as it is included as a core dependency in openstudio-extension.

--- a/openstudio-gems.gemspec
+++ b/openstudio-gems.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
   # runtime dependency versions should be specified as exact versions when merged to master or develop
   spec.add_dependency 'openstudio-extension', '0.2.1'
   spec.add_dependency 'openstudio-workflow', '2.0.0'
-  spec.add_dependency 'openstudio_measure_tester', '0.2.1'
+  spec.add_dependency 'openstudio_measure_tester', '0.2.2'
+
   #spec.add_dependency 'openstudio-standards', '0.2.11-rc1'
   spec.add_dependency 'parallel', '1.19.1'
   #spec.add_dependency 'pycall', '1.3.0.dev'

--- a/openstudio-gems.gemspec
+++ b/openstudio-gems.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'openstudio-workflow', '2.0.0'
   spec.add_dependency 'openstudio_measure_tester', '0.2.2'
 
-  #spec.add_dependency 'openstudio-standards', '0.2.11-rc1'
   spec.add_dependency 'parallel', '1.19.1'
   #spec.add_dependency 'pycall', '1.3.0.dev'
 


### PR DESCRIPTION
This version downgrades rubocop to 0.54 which does not rely on jaro_winkler.