### PR TITLE
Upgrade extension gem to 0.2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,7 @@ gemspec
 # Specify specific gem source/location (e.g. github branch) for running bundle in this directory
 # This is needed if the version of the gem you want to use is not on rubygems
 
-gem 'openstudio-extension', '= 0.2.1'
-# TODO: Temp
+gem 'openstudio-extension', '= 0.2.3'
 
 gem 'openstudio-workflow', '= 2.0.0'
 #gem 'openstudio-workflow', :github => 'NREL/OpenStudio-workflow-gem', :ref => '3e62211b29e28d341c4a84794f35a772c91a2145'

--- a/openstudio-gems.gemspec
+++ b/openstudio-gems.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   # gem version is specified in gemspec, gem source/location (e.g. github branch) can be specified in Gemfile
   # runtime dependency versions can be loosened while in development on branches if needed
   # runtime dependency versions should be specified as exact versions when merged to master or develop
-  spec.add_dependency 'openstudio-extension', '0.2.1'
+  spec.add_dependency 'openstudio-extension', '0.2.3'
   spec.add_dependency 'openstudio-workflow', '2.0.0'
   spec.add_dependency 'openstudio_measure_tester', '0.2.2'
 


### PR DESCRIPTION
Changes since the previous version:

* Use new version of rubocop style from S3
* Remove frozen string literals in comments
* Exclude measure tests from being released with the gem (reduces the size of the installed gem significantly)
* Add BCL commands to upload measures
* Update GitHub changelog gem to use Octokit compared to github_api (which was last released 3 years ago)
* Promote GitHub changelog creation to a rake task to be inherited by all downstream extension gems
