### PR TITLE
bump version of openstudio-workflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,8 @@ gemspec
 # Specify specific gem source/location (e.g. github branch) for running bundle in this directory
 # This is needed if the version of the gem you want to use is not on rubygems
 
-gem 'openstudio-extension', '= 0.2.5'
+# gem 'openstudio-extension', '= 0.2.5'
+gem 'openstudio-extension', :github => 'NREL/openstudio-extension-gem', :ref => '3_1_0_upgrade'
 
 gem 'openstudio-workflow', '= 2.1.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ gemspec
 gem 'openstudio-extension', '= 0.3.0'
 gem 'openstudio-workflow', '= 2.1.0'
 
-#gem 'openstudio-standards', '= 0.2.12.rc2'
-gem 'openstudio-standards', :github => 'NREL/openstudio-standards', :ref => 'v0_2_12_rc3'
+gem 'openstudio-standards', '= 0.2.12.rc4'
+#gem 'openstudio-standards', :github => 'NREL/openstudio-standards', :ref => 'v0_2_12_rc3'
 
 group :native_ext do
   gem 'pycall', '= 1.2.1', :github => 'NREL/pycall.rb', :ref => '5d60b274ac646cdb422a436aad98b40ef8b902b8'

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gemspec
 
 gem 'openstudio-extension', '= 0.2.5'
 
-gem 'openstudio-workflow', '= 2.0.1'
+gem 'openstudio-workflow', '= 2.1.0'
 
 #gem 'openstudio-standards', '= 0.2.12.rc2'
 gem 'openstudio-standards', :github => 'NREL/openstudio-standards', :ref => 'v0_2_12_rc3'

--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,7 @@ gemspec
 # Specify specific gem source/location (e.g. github branch) for running bundle in this directory
 # This is needed if the version of the gem you want to use is not on rubygems
 
-# gem 'openstudio-extension', '= 0.2.5'
-gem 'openstudio-extension', :github => 'NREL/openstudio-extension-gem', :ref => '3_1_0_upgrade'
-
+gem 'openstudio-extension', '= 0.3.0'
 gem 'openstudio-workflow', '= 2.1.0'
 
 #gem 'openstudio-standards', '= 0.2.12.rc2'

--- a/openstudio-gems.gemspec
+++ b/openstudio-gems.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   # gem version is specified in gemspec, gem source/location (e.g. github branch) can be specified in Gemfile
   # runtime dependency versions can be loosened while in development on branches if needed
   # runtime dependency versions should be specified as exact versions when merged to master or develop
-  spec.add_dependency 'openstudio-extension', '0.2.5'
+  spec.add_dependency 'openstudio-extension', '0.2.6'
   spec.add_dependency 'openstudio-workflow', '2.1.0'
   spec.add_dependency 'openstudio_measure_tester', '~> 0.2.3'
 

--- a/openstudio-gems.gemspec
+++ b/openstudio-gems.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   # runtime dependency versions can be loosened while in development on branches if needed
   # runtime dependency versions should be specified as exact versions when merged to master or develop
   spec.add_dependency 'openstudio-extension', '0.2.5'
-  spec.add_dependency 'openstudio-workflow', '2.0.1'
+  spec.add_dependency 'openstudio-workflow', '2.1.0'
   spec.add_dependency 'openstudio_measure_tester', '~> 0.2.3'
 
   spec.add_dependency 'parallel', '1.19.1'

--- a/openstudio-gems.gemspec
+++ b/openstudio-gems.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   # gem version is specified in gemspec, gem source/location (e.g. github branch) can be specified in Gemfile
   # runtime dependency versions can be loosened while in development on branches if needed
   # runtime dependency versions should be specified as exact versions when merged to master or develop
-  spec.add_dependency 'openstudio-extension', '0.2.6'
+  spec.add_dependency 'openstudio-extension', '0.3.0'
   spec.add_dependency 'openstudio-workflow', '2.1.0'
   spec.add_dependency 'openstudio_measure_tester', '~> 0.2.3'
 


### PR DESCRIPTION
@tijcolem -- Rubygems.org is taking a while to recognize the release, but it is there: https://rubygems.org/gems/openstudio-workflow