### PR TITLE
Bump extension gem to the 0.2.6 banch 3_1_0_upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,8 @@ gemspec
 # Specify specific gem source/location (e.g. github branch) for running bundle in this directory
 # This is needed if the version of the gem you want to use is not on rubygems
 
-gem 'openstudio-extension', '= 0.2.5'
+# gem 'openstudio-extension', '= 0.2.5'
+gem 'openstudio-extension', :github => 'NREL/openstudio-extension-gem', :ref => '3_1_0_upgrade'
 
 gem 'openstudio-workflow', '= 2.1.0'
 

--- a/openstudio-gems.gemspec
+++ b/openstudio-gems.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   # gem version is specified in gemspec, gem source/location (e.g. github branch) can be specified in Gemfile
   # runtime dependency versions can be loosened while in development on branches if needed
   # runtime dependency versions should be specified as exact versions when merged to master or develop
-  spec.add_dependency 'openstudio-extension', '0.2.5'
+  spec.add_dependency 'openstudio-extension', '0.2.6'
   spec.add_dependency 'openstudio-workflow', '2.1.0'
   spec.add_dependency 'openstudio_measure_tester', '~> 0.2.3'
 


### PR DESCRIPTION
https://github.com/NREL/openstudio-extension-gem/tree/3_1_0_upgrade

Had to do that otherwise you get:

```
Resolving dependencies...

Bundler could not find compatible versions for gem "openstudio-workflow":

  In Gemfile:

    openstudio-gems was resolved to 3.1.0.pre.rc1, which depends on

      openstudio-extension (= 0.2.5) was resolved to 0.2.5, which depends on

        openstudio-workflow (~> 2.0.0)


    openstudio-gems was resolved to 3.1.0.pre.rc1, which depends on

      openstudio-workflow (= 2.1.0)

rake aborted!

```