### PR TITLE
extension version to 0.4.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gemspec
 # Specify specific gem source/location (e.g. github branch) for running bundle in this directory
 # This is needed if the version of the gem you want to use is not on rubygems
 
-gem 'openstudio-extension', '= 0.4.3'
+gem 'openstudio-extension', '= 0.4.4'
 gem 'openstudio-workflow', '= 2.2.1'
 
 gem 'openstudio-standards', '= 0.2.14'

--- a/openstudio-gems.gemspec
+++ b/openstudio-gems.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   # gem version is specified in gemspec, gem source/location (e.g. github branch) can be specified in Gemfile
   # runtime dependency versions can be loosened while in development on branches if needed
   # runtime dependency versions should be specified as exact versions when merged to master or develop
-  spec.add_dependency 'openstudio-extension', '0.4.3'
+  spec.add_dependency 'openstudio-extension', '0.4.4'
   spec.add_dependency 'openstudio-workflow', '2.2.1'
   spec.add_dependency 'openstudio_measure_tester', '~> 0.3.1'
 


### PR DESCRIPTION
This PR bumps OpenStudio Extension to 0.4.4 which bumps BCL to a new version with security updates