### PR TITLE
update standards gem 0.2.16 and bump version to 3.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gemspec
 gem 'openstudio-extension', '= 0.5.1'
 gem 'openstudio-workflow', '= 2.3.1'
 
-gem 'openstudio-standards', '= 0.2.16.rc2'
+gem 'openstudio-standards', '= 0.2.16'
 
 group :native_ext do
   gem 'pycall', '= 1.2.1', :github => 'NREL/pycall.rb', :ref => '5d60b274ac646cdb422a436aad98b40ef8b902b8'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gemspec
 gem 'openstudio-extension', '= 0.5.1'
 gem 'openstudio-workflow', '= 2.3.1'
 
-gem 'openstudio-standards', '= 0.2.16.rc1'
+gem 'openstudio-standards', '= 0.2.16.rc2'
 
 group :native_ext do
   gem 'pycall', '= 1.2.1', :github => 'NREL/pycall.rb', :ref => '5d60b274ac646cdb422a436aad98b40ef8b902b8'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gemspec
 gem 'openstudio-extension', '= 0.5.1'
 gem 'openstudio-workflow', '= 2.3.1'
 
-gem 'openstudio-standards', '= 0.2.15'
+gem 'openstudio-standards', '= 0.2.16.rc1'
 
 group :native_ext do
   gem 'pycall', '= 1.2.1', :github => 'NREL/pycall.rb', :ref => '5d60b274ac646cdb422a436aad98b40ef8b902b8'

--- a/openstudio-gems.gemspec
+++ b/openstudio-gems.gemspec
@@ -2,7 +2,7 @@ $static = true
 
 Gem::Specification.new do |spec|
   spec.name          = 'openstudio-gems'
-  spec.version       = '3.3.0'
+  spec.version       = '3.4.0.rc1'
   spec.authors       = ['Nicholas Long', 'Dan Macumber', 'Katherine Fleming']
   spec.email         = ['nicholas.long@nrel.gov', 'daniel.macumber@nrel.gov', 'katherine.fleming@nrel.gov']
 

--- a/openstudio-gems.gemspec
+++ b/openstudio-gems.gemspec
@@ -2,7 +2,7 @@ $static = true
 
 Gem::Specification.new do |spec|
   spec.name          = 'openstudio-gems'
-  spec.version       = '3.4.0.rc1'
+  spec.version       = '3.4.0'
   spec.authors       = ['Nicholas Long', 'Dan Macumber', 'Katherine Fleming']
   spec.email         = ['nicholas.long@nrel.gov', 'daniel.macumber@nrel.gov', 'katherine.fleming@nrel.gov']
 


### PR DESCRIPTION
Updating to use the latest standards gem https://rubygems.org/gems/openstudio-standards/versions/0.2.16 and preparing for v3.4.0 release