### PR TITLE
Add flag for release candidates gem

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,7 +218,8 @@ jobs:
         Import-Module $devShellModule
         Enter-VsDevShell -VsInstallPath $vspath -SkipAutomaticLocation -Arch amd64
         conan install . --output-folder=../os-gems-deps --build=missing -s:a build_type=Release -s:a compiler.cppstd=20 -o '*/*:shared=False' -c tools.env.virtualenv:powershell=True
-        ..\os-gems-deps\conanbuild.ps1
+        & cat ..\os-gems-deps\conanbuild.ps1
+        & ..\os-gems-deps\conanbuild.ps1
         ruby --version
         sqlite3 --version
         echo $env:PKG_CONFIG_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,7 +218,7 @@ jobs:
         Import-Module $devShellModule
         Enter-VsDevShell -VsInstallPath $vspath -SkipAutomaticLocation -Arch amd64
         conan install . --output-folder=../os-gems-deps --build=missing -s:a build_type=Release -s:a compiler.cppstd=20 -o '*/*:shared=False' -c tools.env.virtualenv:powershell=True
-        & cat ..\os-gems-deps\conanbuild.ps1
+        cat ..\os-gems-deps\conanbuild.ps1
         & ..\os-gems-deps\conanbuild.ps1
         ruby --version
         sqlite3 --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,7 +218,7 @@ jobs:
         Import-Module $devShellModule
         Enter-VsDevShell -VsInstallPath $vspath -SkipAutomaticLocation -Arch amd64
         conan install . --output-folder=../os-gems-deps --build=missing -s:a build_type=Release -s:a compiler.cppstd=20 -o '*/*:shared=False' -c tools.env.virtualenv:powershell=True
-        & ..\os-gems-deps\conanbuild.ps1
+        ..\os-gems-deps\conanbuild.ps1
         ruby --version
         sqlite3 --version
         echo $env:PKG_CONFIG_PATH

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ if LOCAL_DEV
   if !MINIMAL_GEMS
     gem 'tbd', path: '../tbd'
     gem 'osut', path: '../osut'
-    gem 'openstudio-standards', '= 0.6.0.rc1', path: '../openstudio-standards'
+    gem 'openstudio-standards', '= 0.6.0.rc2', path: '../openstudio-standards'
     gem 'openstudio-extension', '= 0.8.0', path: '../openstudio-extension-gem'
     gem 'openstudio-workflow', '= 2.4.0', path: '../OpenStudio-workflow-gem'
     gem 'openstudio_measure_tester', '= 0.4.0', path: "../OpenStudio-measure-tester-gem"
@@ -121,11 +121,17 @@ else
     gem 'tbd', '= 3.4.1'
     gem 'osut', '= 0.5.0'
 
-    gem 'openstudio-standards', '= 0.6.0.rc1', :github => 'NREL/openstudio-standards', :ref => 'v0.6.0.rc1'
-    gem 'openstudio-extension', '= 0.8.0',:github => 'NREL/openstudio-extension-gem', :ref => '2e86077dce1688443cca462feda3239ef47c232c'
-    gem 'openstudio-workflow', '= 2.4.0', :github => 'NREL/OpenStudio-workflow-gem', :ref => '32126e9b9f6bd6ed1ee55331f6dadbb3ba1e7cd2'
-    gem 'openstudio_measure_tester', '= 0.4.0', :github => 'NREL/OpenStudio-measure-tester-gem', :ref => '89b9b7eb5f2d2ef91e225585a09e076577f25d4a'
-    gem 'bcl', "= 0.8.0", :github => 'NREL/bcl-gem', :ref => '3c60cadc781410819e7c9bfb8d7ba1af146d9abd'
+    # gem 'openstudio-standards', '= 0.6.0.rc1', :github => 'NREL/openstudio-standards', :ref => 'v0.6.0.rc1'
+    # gem 'openstudio-extension', '= 0.8.0',:github => 'NREL/openstudio-extension-gem', :ref => '2e86077dce1688443cca462feda3239ef47c232c'
+    # gem 'openstudio-workflow', '= 2.4.0', :github => 'NREL/OpenStudio-workflow-gem', :ref => '32126e9b9f6bd6ed1ee55331f6dadbb3ba1e7cd2'
+    # gem 'openstudio_measure_tester', '= 0.4.0', :github => 'NREL/OpenStudio-measure-tester-gem', :ref => '89b9b7eb5f2d2ef91e225585a09e076577f25d4a'
+    # gem 'bcl', "= 0.8.0", :github => 'NREL/bcl-gem', :ref => '3c60cadc781410819e7c9bfb8d7ba1af146d9abd'
+    gem 'openstudio-standards', '= 0.6.0.rc2'
+    gem 'openstudio-extension', '= 0.8.0'
+    gem 'openstudio-workflow', '= 2.4.0'
+    gem 'openstudio_measure_tester', '= 0.4.0'
+    gem 'bcl', "= 0.8.0"
+
   end
 
   group :native_ext do

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,8 @@ gemspec
 
 LOCAL_DEV = false
 MINIMAL_GEMS = false   # Keep only one non-native gem, and one native
-FINAL_PACKAGE = !ENV['FINAL_PACKAGE'].nil?
+FINAL_PACKAGE = !ENV['FINAL_PACKAGE'].nil? # used to package the final version of the gem, after all gems has been released.
+RC_RELEASE = !ENV['RC_RELEASE'].nil? #used to package the release candidate version of the gem
 
 if !MINIMAL_GEMS
   # Bug in addressable to 2.8.1 and patched version has an issue https://github.com/NREL/OpenStudio/issues/4870
@@ -45,15 +46,16 @@ if LOCAL_DEV
     end
   end
 
-elsif !FINAL_PACKAGE
+elsif RC_RELEASE
 
+  puts "RC_RELEASE"
   gem 'oslg', '= 0.3.0'
 
   if !MINIMAL_GEMS
     gem 'tbd', '= 3.4.1'
     gem 'osut', '= 0.5.0'
 
-    gem 'openstudio-standards', '= 0.6.0.rc1', :github => 'NREL/openstudio-standards', :ref => 'v0.6.0.rc1'
+    gem 'openstudio-standards', '= 0.6.0.rc2'
     gem 'openstudio-extension', '= 0.8.0',:github => 'NREL/openstudio-extension-gem', :ref => '2e86077dce1688443cca462feda3239ef47c232c'
     gem 'openstudio-workflow', '= 2.4.0', :github => 'NREL/OpenStudio-workflow-gem', :ref => '32126e9b9f6bd6ed1ee55331f6dadbb3ba1e7cd2'
     gem 'openstudio_measure_tester', '= 0.4.0', :github => 'NREL/OpenStudio-measure-tester-gem', :ref => '89b9b7eb5f2d2ef91e225585a09e076577f25d4a'
@@ -74,7 +76,8 @@ elsif !FINAL_PACKAGE
       gem 'msgpack', '1.7.2'
     end
   end
-else
+
+elsif FINAL_PACKAGE
 
   puts "FINAL_PACKAGE"
 
@@ -97,6 +100,35 @@ else
     if !MINIMAL_GEMS
       # gem 'sqlite3'
       # gem 'sqlite3'
+      gem 'sqlite3', '= 1.7.2'
+
+      # You need ragel available (version 6.x, eg `ragel_installer/6.10@bincrafters/stable` from conan)
+      gem 'oga', '3.2'
+      # gem 'cbor', '0.5.9.6' # Cbor will require a ton of patching, so disabling it in favor of msgpack (cbor is a fork of msgpack anyways)
+      gem 'msgpack', '1.7.2'
+    end
+  end
+
+else
+  gem 'oslg', '= 0.3.0'
+
+  if !MINIMAL_GEMS
+    gem 'tbd', '= 3.4.1'
+    gem 'osut', '= 0.5.0'
+
+    gem 'openstudio-standards', '= 0.6.0.rc1', :github => 'NREL/openstudio-standards', :ref => 'v0.6.0.rc1'
+    gem 'openstudio-extension', '= 0.8.0',:github => 'NREL/openstudio-extension-gem', :ref => '2e86077dce1688443cca462feda3239ef47c232c'
+    gem 'openstudio-workflow', '= 2.4.0', :github => 'NREL/OpenStudio-workflow-gem', :ref => '32126e9b9f6bd6ed1ee55331f6dadbb3ba1e7cd2'
+    gem 'openstudio_measure_tester', '= 0.4.0', :github => 'NREL/OpenStudio-measure-tester-gem', :ref => '89b9b7eb5f2d2ef91e225585a09e076577f25d4a'
+    gem 'bcl', "= 0.8.0", :github => 'NREL/bcl-gem', :ref => '3c60cadc781410819e7c9bfb8d7ba1af146d9abd'
+  end
+
+  group :native_ext do
+    gem 'jaro_winkler', '= 1.5.6', :github => 'jmarrec/jaro_winkler', :ref => 'msvc-ruby3'
+
+    if !MINIMAL_GEMS
+      # gem 'sqlite3', :github => 'jmarrec/sqlite3-ruby', :ref => 'MSVC_support'
+      # gem 'sqlite3', :github => 'sparklemotion/sqlite3-ruby', :ref => "v1.7.2"
       gem 'sqlite3', '= 1.7.2'
 
       # You need ragel available (version 6.x, eg `ragel_installer/6.10@bincrafters/stable` from conan)

--- a/Gemfile
+++ b/Gemfile
@@ -55,11 +55,16 @@ elsif RC_RELEASE
     gem 'tbd', '= 3.4.1'
     gem 'osut', '= 0.5.0'
 
+    # gem 'openstudio-extension', '= 0.8.0',:github => 'NREL/openstudio-extension-gem', :ref => '2e86077dce1688443cca462feda3239ef47c232c'
+    # gem 'openstudio-workflow', '= 2.4.0', :github => 'NREL/OpenStudio-workflow-gem', :ref => '32126e9b9f6bd6ed1ee55331f6dadbb3ba1e7cd2'
+    # gem 'openstudio_measure_tester', '= 0.4.0', :github => 'NREL/OpenStudio-measure-tester-gem', :ref => '89b9b7eb5f2d2ef91e225585a09e076577f25d4a'
+    # gem 'bcl', "= 0.8.0", :github => 'NREL/bcl-gem', :ref => '3c60cadc781410819e7c9bfb8d7ba1af146d9abd'
     gem 'openstudio-standards', '= 0.6.0.rc2'
-    gem 'openstudio-extension', '= 0.8.0',:github => 'NREL/openstudio-extension-gem', :ref => '2e86077dce1688443cca462feda3239ef47c232c'
-    gem 'openstudio-workflow', '= 2.4.0', :github => 'NREL/OpenStudio-workflow-gem', :ref => '32126e9b9f6bd6ed1ee55331f6dadbb3ba1e7cd2'
-    gem 'openstudio_measure_tester', '= 0.4.0', :github => 'NREL/OpenStudio-measure-tester-gem', :ref => '89b9b7eb5f2d2ef91e225585a09e076577f25d4a'
-    gem 'bcl', "= 0.8.0", :github => 'NREL/bcl-gem', :ref => '3c60cadc781410819e7c9bfb8d7ba1af146d9abd'
+    gem 'openstudio-extension', '= 0.8.0'
+    gem 'openstudio-workflow', '= 2.4.0'
+    gem 'openstudio_measure_tester', '= 0.4.0'
+    gem 'bcl', "= 0.8.0"
+
   end
 
   group :native_ext do
@@ -87,7 +92,7 @@ elsif FINAL_PACKAGE
     gem 'tbd', '= 3.4.1'
     gem 'osut', '= 0.5.0'
 
-    gem 'openstudio-standards', '= 0.6.0.rc1'
+    gem 'openstudio-standards', '= 0.6.0.rc2'
     gem 'openstudio-extension', '= 0.8.0'
     gem 'openstudio-workflow', '= 2.4.0'
     gem 'openstudio_measure_tester', '= 0.4.0'

--- a/README.md
+++ b/README.md
@@ -72,3 +72,28 @@ DATE=20230427 rake make_package
 * Merge down to master
 * Release via github
 * run `rake release` from master
+
+# Recommandations for gem owners
+
+* Gem owners are encouraged to start releasing pre/rc packages on rubygems. It would avoid several issues
+    * Downloading from git is slow for large repositories
+    * It also avoids the issues where they could go into the .bundle/ruby/bundler folder and not .bundle/ruby/gems one (which we worked-around for openstudio-gems by repacking them manually...)
+
+## Need a native gem as a dependency and intend to use the CLI with --bundle
+
+Using a native gem as a dependency can cause conflicts in the CLI. This is because the CLI is statically built, but `bundle install` with your system ruby will build a shared extension.
+We have mostly worked-around this issue by ensuring that any native dependency in the Gemfile.lock that is satisfied by an embedded CLI native gem will be picked up.
+
+But this is fragile and prone to problems.
+
+Anything that is, or indirectly pulls, a native dependency that is already bundled with our CLI should be put in the `:test` group in the Gemfile (or added via `spec.add_development_dependency` which is the same result from the gempsec file). This is because by default `--bundle_without` is `[test]`.
+
+Or in a `:native` group, and you call the CLI with `--bundle_without "test native"`.
+
+That way we don't even run into such issues, the CLI version is used and that's it.
+
+If you definitely need a native gem that is NOT part of the CLI already, then either:
+
+* It should be part of the CLI anyways if you intend to use the CLI to run your thing... So request it, and we'll see if we can compile it statically (for MSVC especially)
+* Otherwise don't try to use the CLI with `--bundle` (via for eg `rake openstudio:test_with_openstudiowhich` uses a CLI call with `--bundle` underneath). 
+        * You **can** use the `openstudio-measure-tester-gem` directly without the `openstudio-extension-gem` and stay in ruby... Or use `Rake::TestTask` or a modified version of that directly.

--- a/build_openstudio_gems.rb
+++ b/build_openstudio_gems.rb
@@ -136,7 +136,7 @@ def make_package(install_dir, tar_exe, expected_ruby_version, bundler_version)
   lib_ext = RbConfig::CONFIG['LIBEXT']
   libs = Dir.glob("./openstudio-gems/**/*.#{lib_ext}")
   lib_names_woext = Set.new(libs.map{|lib| File.basename(lib, File.extname(lib)) })
-  expected = Set.new(["jaro_winkler_ext", "libll", "liboga", "msgpack", "byebug"]) # unf_ext: disabled with json_schemer
+  expected = Set.new(["jaro_winkler_ext", "libll", "liboga", "msgpack", "byebug", "generator", "parser"]) # unf_ext: disabled with json_schemer
   if !is_unix
     expected.add("sqlite3_native") # TODO: I don't understand why we don't have it yet...
   end

--- a/build_openstudio_gems.rb
+++ b/build_openstudio_gems.rb
@@ -3,7 +3,7 @@ require 'time'
 require 'rbconfig'
 require 'open3'
 
-def system_call(cmd, is_final = false)
+def system_call(cmd, is_final = true)
   # This will just unset env variables if defined
   new_env = {}
   new_env['BUNDLER_ORIG_MANPATH'] = nil

--- a/build_openstudio_gems.rb
+++ b/build_openstudio_gems.rb
@@ -3,7 +3,7 @@ require 'time'
 require 'rbconfig'
 require 'open3'
 
-def system_call(cmd, is_final = true)
+def system_call(cmd, is_final = false)
   # This will just unset env variables if defined
   new_env = {}
   new_env['BUNDLER_ORIG_MANPATH'] = nil

--- a/openstudio-gems.gemspec
+++ b/openstudio-gems.gemspec
@@ -2,7 +2,7 @@ $static = true
 
 Gem::Specification.new do |spec|
   spec.name          = 'openstudio-gems'
-  spec.version       = '3.7.0'
+  spec.version       = '3.8.0'
   spec.authors       = ['Nicholas Long', 'Dan Macumber', 'Katherine Fleming']
   spec.email         = ['nicholas.long@nrel.gov', 'daniel.macumber@nrel.gov', 'katherine.fleming@nrel.gov']
 


### PR DESCRIPTION
Tested with:
- no environment variable, the Gemfile will install all packages from github
- set envrionment with `export RC_RELEASE=TRUE` the Gemfile will install `openstudio-standards` from rubygem.org
- set environment to `export FINAL_PACKAGE=TRUE` the Gemfile will try to install the gem packages from rubgem.org

WHY:
If we use Gemfile to fetch the gem from github, it will fetch all codebase even if we points to `ref:`. In most of the gems it's fine but openstudio-standards' release is only ~500 MB but the code base is ~5GB.
Which cause the issue in Openstudio-server.