### PR TITLE
Fork rubocop 1.50.0 to remove json dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,9 @@ elsif !FINAL_PACKAGE
     gem 'openstudio_measure_tester', '= 0.4.0'
     gem 'bcl', "= 0.8.0"
 
+    # This removes the runtime dependency on 'json ~> 2.3'. Our CLI, via ruby
+    # itself already has json 2.6.2 which is good enough
+    gem 'rubocop', :github => 'jmarrec/rubocop', :ref => '1.50.0-no_json'
   end
 
   group :native_ext do

--- a/build_openstudio_gems.rb
+++ b/build_openstudio_gems.rb
@@ -136,7 +136,7 @@ def make_package(install_dir, tar_exe, expected_ruby_version, bundler_version)
   lib_ext = RbConfig::CONFIG['LIBEXT']
   libs = Dir.glob("./openstudio-gems/**/*.#{lib_ext}")
   lib_names_woext = Set.new(libs.map{|lib| File.basename(lib, File.extname(lib)) })
-  expected = Set.new(["jaro_winkler_ext", "libll", "liboga", "msgpack", "byebug", "generator", "parser"]) # unf_ext: disabled with json_schemer
+  expected = Set.new(["jaro_winkler_ext", "libll", "liboga", "msgpack", "byebug"]) # unf_ext: disabled with json_schemer
   if !is_unix
     expected.add("sqlite3_native") # TODO: I don't understand why we don't have it yet...
   end

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -89,12 +89,7 @@ class StaticExtensionPlugin
         elsif extname.to_s == "sqlite3"
           extname = "sqlite3_native"
           extconf_args = ["--enable-system-libraries", "--with-pkg-config=pkgconf"]
-        elsif extname.to_s == 'json'
-          # json has a makefile, but really it's only json/ext/parser and
-          # json/ext/generator that are compiled
-          puts "Not exporting json because it's shallow and doesn't have a static lib (parser and generator do). #{extension_dir.to_s}"
-          next
-        elsif ['unfext', 'byebug', 'msgpack', 'generator', 'parser'].include?(extname.to_s)
+        elsif ['unfext', 'byebug', 'msgpack'].include?(extname.to_s)
           # No-op
         else
           puts "Warning: rubygems_plugin.post_install: no configuration given for extension_dir=#{extension_dir}"


### PR DESCRIPTION
ideally you would fork rubocop onto NREL's umbrella, but whatever, this works for now

https://github.com/rubocop/rubocop/compare/v1.50.0...jmarrec:rubocop:1.50.0-no_json