### PR TITLE
Bumped tbd to 3.4.2 to update json-schema.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,15 +133,18 @@ jobs:
         cat $CONAN_PROFILE_DEFAULT
         # Mac has the FreeBSD flavor of sed and MUST take a backup suffix...
         sed -i.bak 's/cppstd=.*$/cppstd=20/g' $CONAN_PROFILE_DEFAULT
-        # if [ "${{ matrix.compiler}}" == "Visual Studio" ]; then
-        #   # Remove these
-        #   sed -i.bak '/cppstd=.*/d' $CONAN_PROFILE_DEFAULT
-        #   sed -i.bak '/compiler.runtime/d' $CONAN_PROFILE_DEFAULT
-        #   sed -i.bak '/compiler.version/d' $CONAN_PROFILE_DEFAULT
-        #   # Set to visual studio
-        #   sed -i.bak 's/compiler=.*$/compiler=${{ matrix.compiler }}/g' $CONAN_PROFILE_DEFAULT
-        #   sed -i.bak 's/compiler.version=.*$/compiler.version=${{ matrix.version }}/g' $CONAN_PROFILE_DEFAULT
-        # fi
+        # Modify the profile file directly
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          # Use sed with in-place editing
+          sed -i.bak 's/compiler.cppstd=.*$/compiler.cppstd=20/g' "$CONAN_PROFILE_DEFAULT"
+          sed -i.bak 's/compiler.version=.*$/compiler.version=193/g' "$CONAN_PROFILE_DEFAULT"
+          sed -i.bak 's/compiler.runtime=.*$/compiler.runtime=dynamic/g' "$CONAN_PROFILE_DEFAULT"
+          sed -i.bak 's/compiler.runtime_type=.*$/compiler.runtime_type=Release/g' "$CONAN_PROFILE_DEFAULT"
+          # Remove any existing vcvars_ver configuration
+          sed -i.bak '/tools.microsoft.msbuild:vcvars_ver/d' "$CONAN_PROFILE_DEFAULT"
+          # Add the correct vs_version
+          echo -e "\n[conf]\ntools.microsoft.msbuild:vs_version=17" >> "$CONAN_PROFILE_DEFAULT"
+        fi
         rm -Rf $CONAN_PROFILE_DEFAULT.bak || true
         conan profile show
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,27 +207,47 @@ jobs:
         gem install rake
         rake make_package
 
+    - name: List Installed MSVC Toolsets
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        Get-ChildItem "C:\Program Files\Microsoft Visual Studio\2022\*" -Directory | ForEach-Object {
+            $msvcPath = "$($_.FullName)\VC\Tools\MSVC"
+            if (Test-Path $msvcPath) {
+                Write-Host "MSVC Toolsets in $msvcPath"
+                Get-ChildItem $msvcPath -Directory
+            }
+        }
+      
+
     - name: Build Windows
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        # Set-PSDebug -Trace 1
-        # LongPathsEnabled is already the case for the runner: https://github.com/actions/runner-images/blob/13d5100df5e7d490b069f0e284dffbc8e321a756/images/windows/scripts/build/Configure-BaseImage.ps1#L73
-        # But git isn't
+        # Enable long paths for Git
         git config --system core.longpaths true
-        # As of 2024-02-13, this commit isn't in conan v2 https://github.com/conan-io/conan/commit/f2b56352f6f597981ccc053f9b7982029b942bf2
-        $vspath=$(vswhere -products '*' -requires Microsoft.Component.MSBuild -property installationPath -latest)
-        $devShellModule = "$vspath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
-        Import-Module $devShellModule
-        Enter-VsDevShell -VsInstallPath $vspath -SkipAutomaticLocation -Arch amd64
-        conan install . --output-folder=../os-gems-deps --build=missing -s:a build_type=Release -s:a compiler.cppstd=20 -o '*/*:shared=False' -c tools.env.virtualenv:powershell=True
+    
+        # Install dependencies using Conan
+        conan install . --output-folder=../os-gems-deps --build=missing `
+          -s build_type=Release `
+          -s compiler.cppstd=20 `
+          -o '*/*:shared=False' `
+          -c tools.env.virtualenv:powershell=True `
+          --conf 'tools.microsoft.msbuild:vs_version=17' `
+          --conf 'tools.microsoft.msbuild:vs_toolset_version=14.29'
+        
+        # Activate the Conan build environment
         & ..\os-gems-deps\conanbuild.ps1
+    
+        # Display versions for debugging
         ruby --version
         sqlite3 --version
         echo $env:PKG_CONFIG_PATH
+    
+        # Install Ruby gems and build the package
         gem install rake
         rake make_package
-
+  
     - name: Archive TGZ or ZIP artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           allow_failure: false
         - build_name: msvc-2022
           compiler: msvc
-          version: 193
+          version: 194
           os: windows-2022
           allow_failure: false
 
@@ -71,7 +71,7 @@ jobs:
       shell: bash
       run: |
         set -x
-        pip install conan==2.2.2
+        pip install conan==2.3.2
 
         conan --version
         if [ "$RUNNER_OS" == "Windows" ]; then
@@ -133,18 +133,15 @@ jobs:
         cat $CONAN_PROFILE_DEFAULT
         # Mac has the FreeBSD flavor of sed and MUST take a backup suffix...
         sed -i.bak 's/cppstd=.*$/cppstd=20/g' $CONAN_PROFILE_DEFAULT
-        # Modify the profile file directly
-        if [ "$RUNNER_OS" == "Windows" ]; then
-          # Use sed with in-place editing
-          sed -i.bak 's/compiler.cppstd=.*$/compiler.cppstd=20/g' "$CONAN_PROFILE_DEFAULT"
-          sed -i.bak 's/compiler.version=.*$/compiler.version=193/g' "$CONAN_PROFILE_DEFAULT"
-          sed -i.bak 's/compiler.runtime=.*$/compiler.runtime=dynamic/g' "$CONAN_PROFILE_DEFAULT"
-          sed -i.bak 's/compiler.runtime_type=.*$/compiler.runtime_type=Release/g' "$CONAN_PROFILE_DEFAULT"
-          # Remove any existing vcvars_ver configuration
-          sed -i.bak '/tools.microsoft.msbuild:vcvars_ver/d' "$CONAN_PROFILE_DEFAULT"
-          # Add the correct vs_version
-          echo -e "\n[conf]\ntools.microsoft.msbuild:vs_version=17" >> "$CONAN_PROFILE_DEFAULT"
-        fi
+        # if [ "${{ matrix.compiler}}" == "Visual Studio" ]; then
+        #   # Remove these
+        #   sed -i.bak '/cppstd=.*/d' $CONAN_PROFILE_DEFAULT
+        #   sed -i.bak '/compiler.runtime/d' $CONAN_PROFILE_DEFAULT
+        #   sed -i.bak '/compiler.version/d' $CONAN_PROFILE_DEFAULT
+        #   # Set to visual studio
+        #   sed -i.bak 's/compiler=.*$/compiler=${{ matrix.compiler }}/g' $CONAN_PROFILE_DEFAULT
+        #   sed -i.bak 's/compiler.version=.*$/compiler.version=${{ matrix.version }}/g' $CONAN_PROFILE_DEFAULT
+        # fi
         rm -Rf $CONAN_PROFILE_DEFAULT.bak || true
         conan profile show
 
@@ -207,47 +204,27 @@ jobs:
         gem install rake
         rake make_package
 
-    - name: List Installed MSVC Toolsets
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        Get-ChildItem "C:\Program Files\Microsoft Visual Studio\2022\*" -Directory | ForEach-Object {
-            $msvcPath = "$($_.FullName)\VC\Tools\MSVC"
-            if (Test-Path $msvcPath) {
-                Write-Host "MSVC Toolsets in $msvcPath"
-                Get-ChildItem $msvcPath -Directory
-            }
-        }
-      
-
     - name: Build Windows
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        # Enable long paths for Git
+        # Set-PSDebug -Trace 1
+        # LongPathsEnabled is already the case for the runner: https://github.com/actions/runner-images/blob/13d5100df5e7d490b069f0e284dffbc8e321a756/images/windows/scripts/build/Configure-BaseImage.ps1#L73
+        # But git isn't
         git config --system core.longpaths true
-    
-        # Install dependencies using Conan
-        conan install . --output-folder=../os-gems-deps --build=missing `
-          -s build_type=Release `
-          -s compiler.cppstd=20 `
-          -o '*/*:shared=False' `
-          -c tools.env.virtualenv:powershell=True `
-          --conf 'tools.microsoft.msbuild:vs_version=17' `
-          --conf 'tools.microsoft.msbuild:vs_toolset_version=14.29'
-        
-        # Activate the Conan build environment
+        # As of 2024-02-13, this commit isn't in conan v2 https://github.com/conan-io/conan/commit/f2b56352f6f597981ccc053f9b7982029b942bf2
+        $vspath=$(vswhere -products '*' -requires Microsoft.Component.MSBuild -property installationPath -latest)
+        $devShellModule = "$vspath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+        Import-Module $devShellModule
+        Enter-VsDevShell -VsInstallPath $vspath -SkipAutomaticLocation -Arch amd64
+        conan install . --output-folder=../os-gems-deps --build=missing -s:a build_type=Release -s:a compiler.cppstd=20 -o '*/*:shared=False' -c tools.env.virtualenv:powershell=True
         & ..\os-gems-deps\conanbuild.ps1
-    
-        # Display versions for debugging
         ruby --version
         sqlite3 --version
         echo $env:PKG_CONFIG_PATH
-    
-        # Install Ruby gems and build the package
         gem install rake
         rake make_package
-  
+
     - name: Archive TGZ or ZIP artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        build_name: [gcc-10, apple-clang-11, apple-clang-14-armv8, msvc-2022]
+        build_name: [gcc-10, apple-clang-13, apple-clang-14-armv8, msvc-2022]
         include:
         - build_name: gcc-10
           compiler: gcc
@@ -34,11 +34,12 @@ jobs:
           os: ubuntu-20.04
           # dockerImage: conanio/gcc10-ubuntu16.04:latest
           allow_failure: false
-        - build_name: apple-clang-11
+        - build_name: apple-clang-13
           compiler: apple-clang
-          version: 11
-          os: macos-11
-          SDKROOT: /Applications/Xcode_11.7.app
+          version: 13
+          os: macos-12
+          arch: x86_64
+          SDKROOT: /Applications/Xcode_13.2.1.app
           allow_failure: false
         - build_name: apple-clang-14-armv8
           compiler: apple-clang

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ elsif !FINAL_PACKAGE
   gem 'oslg', '= 0.3.0'
 
   if !MINIMAL_GEMS
-    gem 'tbd', '= 3.4.1'
+    gem 'tbd', '= 3.4.2'
     gem 'osut', '= 0.5.0'
 
     # gem 'openstudio-standards', '= 0.6.0.rc1', :github => 'NREL/openstudio-standards', :ref => 'v0.6.0.rc1'
@@ -96,7 +96,7 @@ else
   gem 'oslg', '= 0.3.0'
 
   if !MINIMAL_GEMS
-    gem 'tbd', '= 3.4.1'
+    gem 'tbd', '= 3.4.2'
     gem 'osut', '= 0.5.0'
 
     gem 'openstudio-standards', '= 0.6.1'


### PR DESCRIPTION
https://github.com/urbanopt/urbanopt-geojson-gem/blob/develop/lib/urbanopt/geojson/feature.rb#L285
And
https://github.com/urbanopt/urbanopt-geojson-gem/blob/develop/lib/urbanopt/geojson/geo_file.rb#L223

Is using the json-schema from OS-gems

And the OS-gems is using the json-schema from tbd, which should be and has been updated from Juliens' PR:

https://github.com/NREL/openstudio-gems/pull/95

Something further todo:

https://github.com/NREL/OpenStudio/blob/ba1b94b6542c1f1d4cdcdb775886852b9a82bc4f/ruby/bindings/InitRubyBindings.cpp#L474

Remove the require stringio in Openstudio.

Related issue:

https://github.com/NREL/OpenStudio/issues/4969 (From Openstudio side)


https://github.com/urbanopt/urbanopt-core-gem/pull/59 (To use os3.8 with Ruby3)