### PR TITLE
Add webrick to gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ if !MINIMAL_GEMS
   gem 'regexp_parser', '2.9.0'
 end
 
+gem 'webrick', '~> 1.8.2'
+
 if LOCAL_DEV
 
   gem 'oslg', path: '../oslg'

--- a/openstudio-gems.gemspec
+++ b/openstudio-gems.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'openstudio_measure_tester', '~> 0.4.0'
 
   spec.add_dependency 'parallel', '1.19.1'
+  spec.add_dependency 'webrick', '~> 1.8.2'
 
   # development dependencies need not be specified so strictly
   # these will not be enforced by consumers of this spec


### PR DESCRIPTION
In OS 3.8.0, when trying to launch the measure manager server in classic CLI (`openstudio classic measure -s 3100`), here is what we get:

```
Ignoring debug-1.7.1 because its extensions are not built. Try: gem pristine debug --version 1.7.1
Ignoring rbs-2.8.2 because its extensions are not built. Try: gem pristine rbs --version 2.8.2
Error executing argv: ["measure", "-s", "3100"]
Error: cannot load such file -- webrick in eval:182:in `require'
eval:182:in `require'
<internal::/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
:/measure_manager_server.rb:7:in `<main>'
eval:236:in `eval'
eval:236:in `require_embedded_absolute'
eval:169:in `require'
<internal::/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
eval:253:in `require_relative'
:/openstudio_cli.rb:1603:in `execute'
:/openstudio_cli.rb:827:in `execute'
:/openstudio_cli.rb:1994:in `<main>'
eval:236:in `eval'
eval:236:in `require_embedded_absolute'
eval:221:in `block in require_embedded'
eval:215:in `each'
eval:215:in `require_embedded'
eval:174:in `require'
eval:3:in `<main>'
```

The issue is that OS needs to include _Webrick_ gem.
Since Webrick has not been included in Ruby since 3.0.0 (https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/), I suggest adding it to the Gemfile here, as I have indicated in https://github.com/NREL/OpenStudio-server/pull/793.

It fixes https://github.com/NREL/OpenStudio-PAT/issues/276.
