### PR TITLE
#5423 - add rubocop & plugins and simplecov & plugins back in

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        build_name: [gcc-10, apple-clang-13, apple-clang-14-armv8, msvc-2022]
+        build_name: [gcc-10, apple-clang-13, apple-clang-14-armv8, msvc-2022, gcc-10-arm64]
         include:
         - build_name: gcc-10
           compiler: gcc
@@ -52,6 +52,12 @@ jobs:
           version: 194
           os: windows-2022
           allow_failure: false
+        - build_name: gcc-10-arm64
+          compiler: gcc
+          version: 10
+          os: ubuntu-22.04-arm
+          # dockerImage: conanio/gcc10-ubuntu16.04:latest
+          allow_failure: true
 
     steps:
     - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -111,9 +111,7 @@ else
     gem 'openstudio_measure_tester', '= 0.5.0'
     gem 'bcl', "= 0.9.0"
 
-    # This removes the runtime dependency on 'json ~> 2.3'. Our CLI, via ruby
-    # itself already has json 2.6.2 which is good enough
-    gem 'rubocop', :github => 'jmarrec/rubocop', :ref => '1.50.0-no_json'
+    gem 'rubocop', '= 1.50.0'
   end
 
   group :native_ext do

--- a/openstudio-gems.gemspec
+++ b/openstudio-gems.gemspec
@@ -29,4 +29,8 @@ Gem::Specification.new do |spec|
   # bundle version is parsed by build_openstudio_gems.rb, specify all three numbers
   spec.add_development_dependency 'bundler', '~> 2.4.10'
   spec.add_development_dependency 'rake', '~> 13.2.1'
+  spec.add_development_dependency 'rubocop', '1.50.0'
+  spec.add_development_dependency 'rubocop-checkstyle_formatter', '0.6.0'
+  spec.add_development_dependency 'rubocop-performance', '1.20.0'
+  spec.add_development_dependency 'simplecov', '0.22.0'
 end


### PR DESCRIPTION
* Hotfix for #114 
     * Never pull from a git remote in FINAL_PACKAGE block in gemfile... I know it's awfully complicated shenanigans all around, but it's what it is...
* Crudish fix for https://github.com/NREL/OpenStudio/issues/5423
* Related to https://github.com/NREL/OpenStudio-measure-tester-gem/issues/94

I have checked that this allows me to run the measure tests again